### PR TITLE
Fix getByNameOrId() and cache jQuery selector

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -59,12 +59,18 @@ var Utils = {
     return obj instanceof RegExp
   },
   getByNameOrId: function (str) {
-    if ($('[name="'+ str +'"]').length)
-      return $('[name="'+ str +'"]')
-    else if ($('[name="'+ str +'"]').length)
-      return $('#' + str)
-    else
-      $.error('The field "'+ str + '" doesn\'t exist.')
+    var $element = $('[name="'+ str +'"]');
+    if ($element.length)
+	{
+	 return $element;
+	}
+     
+	$element = $('#' + str);
+	if ($element.length)
+	{
+	 return $element;
+	}
+	$.error('The field "'+ str + '" doesn\'t exist.')
   },
   /**
    * Determine type of any Ideal Forms element


### PR DESCRIPTION
Original code was just getting the [name=] twice and could never return by id. Also it was unnecessarily causing jQuery to find the selector multiple times.

Corrected to find by id if [name] not found, else return a message. Caches selectors.
