### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/node_modules/grunt-contrib-compress/node_modules/archiver/CONTRIBUTING.md
+++ b/node_modules/grunt-contrib-compress/node_modules/archiver/CONTRIBUTING.md
@@ -11,4 +11,4 @@
 
 * tests should be added to the nodeunit configs in `tests/`
 * tests can be run with `npm test`
-* see existing tests for guidance
+* see existing tests for guidanc

--- a/node_modules/grunt-contrib-compress/node_modules/archiver/README.md
+++ b/node_modules/grunt-contrib-compress/node_modules/archiver/README.md
@@ -115,4 +115,4 @@ Originally inspired by Antoine van Wel's [node-zipstream](https://github.com/wel
 
 ## Licensing
 
-This project's code is licensed under the MIT license. see [LICENSE-MIT](https://github.com/ctalkington/node-archiver/blob/master/LICENSE-MIT).
+This project's code is licensed under the MIT license. see [LICENSE-MIT](https://github.com/ctalkington/node-archiver/blob/master/LICENSE-MIT)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
